### PR TITLE
Changed URLs to use https

### DIFF
--- a/tilde_ring/join.html
+++ b/tilde_ring/join.html
@@ -5,12 +5,12 @@
     <title>join the tilde.town ~ring</title> 
     <link rel="stylesheet"
           type="text/css"
-          href="http://tilde.town/~um/default.css"
+          href="https://tilde.town/~um/default.css"
           media="screen" />
   </head>
   <body>
 
-<h1>join the <a href="http://tilde.town">tilde.town</a> ~ring!</h1>
+<h1>join the <a href="https://tilde.town">tilde.town</a> ~ring!</h1>
 <p>Browse <a href="members.html">a list of all the ~ring members</a>.</p>
 <hr>
 <p>tilde.town ~users can join by pasting this html code in their <code>index.html</code>:</p>
@@ -21,8 +21,8 @@
         <p> <a id="tilde_town_ring" class="tilde_ring_link" href="">random ~user</a>
           | <a id="random_tildebox" class="tilde_ring_link" href="">random ~box</a>
           | <a id="tilde_town_ring_next" class="tilde_ring_link" href="">next ~user</a> </p>
-        <p><a href="http://tilde.town/~um/tilde_ring/join.html">join</a></p>
-        <script type="text/javascript" src="http://tilde.town/~um/tilde_ring/tilde_ring.js"></script>
+        <p><a href="https://tilde.town/~um/tilde_ring/join.html">join</a></p>
+        <script type="text/javascript" src="https://tilde.town/~um/tilde_ring/tilde_ring.js"></script>
       </div>
     </xmp>
 
@@ -34,20 +34,20 @@
         <li>the join link url</li>
       </ul>
       For an example of the flexibility of the ~ring parts, find
-      <a href="http://tilde.town/~selfsame">~selfsame</a>'s
+      <a href="https://tilde.town/~selfsame">~selfsame</a>'s
       implementation.
     </p>
 
     <p>Note: this is still in beta. Please email ~um@tilde.town or ~dan@tilde.town if there are
       any problems, or catch us in irc.</p>
 
-      <p> Looking for a link to any random tilde.town site? <a href="http://tilde.town/~nick/">~nick</a> has that!</p>
-    <p><a href="http://tilde.town/~um">~um<a/> and <a href="http://tilde.town/~dan/">~dan</a></p>
+      <p> Looking for a link to any random tilde.town site? <a href="https://tilde.town/~nick/">~nick</a> has that!</p>
+    <p><a href="https://tilde.town/~um">~um<a/> and <a href="https://tilde.town/~dan/">~dan</a></p>
     <hr>
    <h3>refine, reimplement, or extend the tilde.town ~ring!</h3>
 
     <p>The ~ring consists of the above html, a javascript file, and
-      <a href="http://tilde.town/~dan/">~dan</a>'s python script
+      <a href="https://tilde.town/~dan/">~dan</a>'s python script
       that gathers ~users data into a json file. The code is
       available on our <a href="https://github.com/aBathologist/tildetown_ring">github repository</a>.
       If you have ideas, please suggest, fork, request pulls, etc.</p>
@@ -59,8 +59,8 @@
         <p> <a id="tilde_town_ring" class="tilde_ring_link" href="">random ~user</a>
           | <a id="random_tildebox" class="tilde_ring_link" href="">random ~box</a>
           | <a id="tilde_town_ring_next" class="tilde_ring_link" href="">next ~user</a> </p>
-        <p><a href="http://tilde.town/~um/tilde_ring/join.html">join</a></p>
-        <script type="text/javascript" src="http://tilde.town/~um/tilde_ring/tilde_ring.js"></script>
+        <p><a href="https://tilde.town/~um/tilde_ring/join.html">join</a></p>
+        <script type="text/javascript" src="https://tilde.town/~um/tilde_ring/tilde_ring.js"></script>
       </div>
   </body>
 </html>

--- a/tilde_ring/tilde_ring.html
+++ b/tilde_ring/tilde_ring.html
@@ -2,7 +2,7 @@
   <p><em>a member of the tilde.town ~ring</em></p>
   <p> <a id="tilde_town_ring" class="tilde_ring_link" href="">Random ~User</a>
     | <a id="random_tildebox" class="tilde_ring_link" href="">Random ~Box</a> </p>
-  <p><a href="http://tilde.town/~um/tilde_ring/join.html">Join</a></p>
-  <script type="text/javascript" src="http://tilde.town/~um/js/tilde_ring.js"></script>
+  <p><a href="https://tilde.town/~um/tilde_ring/join.html">Join</a></p>
+  <script type="text/javascript" src="https://tilde.town/~um/js/tilde_ring.js"></script>
 </div>
 

--- a/tilde_ring/tilde_ring.js
+++ b/tilde_ring/tilde_ring.js
@@ -9,8 +9,8 @@
  *
  * */
 
-var tildeboxlist_urls = 'http://tilde.town/~um/json/othertildes.json';
-var userlist_url = 'http://tilde.town/~dan/users.json';
+var tildeboxlist_urls = 'https://tilde.town/~um/json/othertildes.json';
+var userlist_url = 'https://tilde.town/~dan/users.json';
 
 /*
  *  MAIN FUNCTIONS


### PR DESCRIPTION
Fixes #2 

Changed links to https as it works regardless of whether the page is viewed over https or http, but protocol-relative URLs could also be used if desired.