### PR TITLE
Add protocol relativity

### DIFF
--- a/tilde_ring/tilde_ring.js
+++ b/tilde_ring/tilde_ring.js
@@ -9,8 +9,8 @@
  *
  * */
 
-var tildeboxlist_urls = 'https://tilde.town/~um/json/othertildes.json';
-var userlist_url = 'https://tilde.town/~dan/users.json';
+var tildeboxlist_urls = document.location.protocol + '//tilde.town/~um/json/othertildes.json';
+var userlist_url = document.location.protocol + '//tilde.town/~dan/users.json';
 
 /*
  *  MAIN FUNCTIONS


### PR DESCRIPTION
This uses document.location.protocol to set the protocol that's according to the protocol the JS was loaded using. If the JS is loaded in a protocol, we can safely assume that we can access other same-domain pages using that protocol. This is part 1 of 2 to fix the ring.