### PR TITLE
Use the Python grp module to list town members

### DIFF
--- a/users.py
+++ b/users.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 import grp
 import json
 import hashlib
@@ -39,7 +39,7 @@ def get_users():
 
             # determines whether the file has been edited
             hash = hashlib.new('sha256')
-            with open(index) as f:
+            with open(index, 'rb') as f:
                 hash.update(f.read())
                 if hash.hexdigest() in UNEDITED_INDEX_DIGESTS:
                     edited = 0
@@ -54,7 +54,7 @@ def get_users():
             else:
                 ringmember = 0
 
-        except Exception, e:
+        except Exception:
             continue  # Ignore error. Continue to next user.
 
         # Adds username as a key to the dictionary
@@ -67,4 +67,4 @@ def get_users():
     return json.dumps(users, indent=4)
 
 if __name__ == "__main__":
-    print get_users()
+    print(get_users())

--- a/users.py
+++ b/users.py
@@ -1,8 +1,8 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python2
+import grp
 import json
 import hashlib
 import os.path
-import os
 import time
 
 # sha256sum /etc/skel/public_html/index.html
@@ -15,57 +15,54 @@ def get_users():
     url = "http://tilde.town/~"
 
     # Get the list of users!
-    with open("/etc/passwd", "r") as f:
-        for line in f:
-            exclude = False
-            if "/bin/bash" in line:
-                u = line.split(":")[0]  # Grab all text before first ':'
+    town_group = grp.getgrnam('town')
+    for u in town_group.gr_mem:
+        exclude = False
+        # Exclude list for the feed if required.
+        with open(os.path.expanduser("~/.user_exclude"), "r") as e:
+            for eline in e:
+                if u in eline:
+                    exclude = True
+                    break  # Break just exits the current loop
+        if exclude:
+            continue  # Move on to next user
 
-                # Exclude list for the feed if required.
-                with open(os.path.expanduser("~/.user_exclude"), "r") as e:
-                    for eline in e:
-                        if u in eline:
-                            exclude = True
-                            break  # Break just exits the current loop
-                if exclude:
-                    continue  # Move on to next user
+        folder = "/home/"+u+"/public_html/"
+        index = folder + "index.html"
 
-                folder = "/home/"+u+"/public_html/"
-                index = folder + "index.html"
+        try:
+            # Some system users don't have index.html's
+            # This try/except just supresses the error,
+            # ignores the system user and continues looping.
+            createdtime = time.ctime(os.path.getctime(index))
+            modtime     = time.ctime(os.path.getmtime(index))
 
-                try:
-                    # Some system users don't have index.html's
-                    # This try/except just supresses the error,
-                    # ignores the system user and continues looping.
-                    createdtime = time.ctime(os.path.getctime(index))
-                    modtime     = time.ctime(os.path.getmtime(index))
+            # determines whether the file has been edited
+            hash = hashlib.new('sha256')
+            with open(index) as f:
+                hash.update(f.read())
+                if hash.hexdigest() in UNEDITED_INDEX_DIGESTS:
+                    edited = 0
+                else:
+                    edited = 1
 
-                    # determines whether the file has been edited
-                    hash = hashlib.new('sha256')
-                    with open(index) as f:
-                        hash.update(f.read())
-                        if hash.hexdigest() in UNEDITED_INDEX_DIGESTS:
-                            edited = 0
-                        else:
-                            edited = 1
+            # determines wether the user is a member of the ring,
+            # i.e., whether they have included the ring html in
+            # their index. - um
+            if 'id="tilde_town_ring"' in open(index).read():
+                ringmember = 1
+            else:
+                ringmember = 0
 
-                    # determines wether the user is a member of the ring,
-                    # i.e., whether they have included the ring html in
-                    # their index. - um
-                    if 'id="tilde_town_ring"' in open(index).read():
-                        ringmember = 1
-                    else:
-                        ringmember = 0
+        except Exception, e:
+            continue  # Ignore error. Continue to next user.
 
-                except Exception, e:
-                    continue  # Ignore error. Continue to next user.
-
-                # Adds username as a key to the dictionary
-                # then adds relevant data to that key.
-                # Looks like {"dan": {"homepage": "", "modtime": ""}, "edited": int, "ringmember": int}
-                # Easy enough to change this format if needed later on.
-                # or at other's suggestions.
-                users[u] = {"homepage": url + u, "modtime": modtime, "edited": edited, "ringmember": ringmember}
+        # Adds username as a key to the dictionary
+        # then adds relevant data to that key.
+        # Looks like {"dan": {"homepage": "", "modtime": ""}, "edited": int, "ringmember": int}
+        # Easy enough to change this format if needed later on.
+        # or at other's suggestions.
+        users[u] = {"homepage": url + u, "modtime": modtime, "edited": edited, "ringmember": ringmember}
 
     return json.dumps(users, indent=4)
 


### PR DESCRIPTION
The current implementation of the `users.py` script has an issue with users using any other shell than bash. To distinguish system users from town members, the script ignored any user who was not using `/bin/bash` as their shell; it is however possible for a user to change their login shell using `chsh` on the command line. I changed my own shell to `/usr/bin/zsh` and it made me disappear from the list.

This pull request changes the Python script to use the [`grp`](https://docs.python.org/3.7/library/grp.html#module-grp) module instead and list all members of the `town` group. This group has been manually created and every new town member is automatically added to this group; there are no system users in there. This makes the script no longer care about the user's login shell.

It is also worth noting that this Python script only works with Python 2.x, which will no longer be supported in 2020. I can quickly convert it to Python 3.x if you want me to.